### PR TITLE
Remove old stages from `dvc.lock`

### DIFF
--- a/dvc.lock
+++ b/dvc.lock
@@ -1,43 +1,34 @@
+---
 schema: '2.0'
 stages:
-  1-stage:
-    cmd: Rscript stages/01-stage.R
-    deps:
-    - path: stages/01-stage.R
-      md5: c468dc14527e00c339f146e1dba2bd3b
-      size: 118
-    outs:
-    - path: data/mtcars.parquet
-      md5: 77cf29accf9535522fad7db1486eff9a
-      size: 6243
   download:
     cmd: stages/02_download.sh
     deps:
-    - path: list
-      hash: md5
+    - hash: md5
       md5: 3786630381c3c56720d26e239fd89a94.dir
-      size: 471498
       nfiles: 1
-    - path: stages/02_download.sh
-      hash: md5
+      path: list
+      size: 471498
+    - hash: md5
       md5: 4e31c2579181fc9bac5ee13a3761200c
+      path: stages/02_download.sh
       size: 3256
     outs:
-    - path: download
-      hash: md5
+    - hash: md5
       md5: 5bee88051c751351818d6e24de90dd33.dir
-      size: 105861938093
       nfiles: 3808
+      path: download
+      size: 105861938093
   list:
     cmd: stages/01_list.sh
     deps:
-    - path: stages/01_list.sh
-      hash: md5
+    - hash: md5
       md5: 02e7cadc9df146b2310625db6795fd2f
+      path: stages/01_list.sh
       size: 425
     outs:
-    - path: list
-      hash: md5
+    - hash: md5
       md5: 3786630381c3c56720d26e239fd89a94.dir
-      size: 471498
       nfiles: 1
+      path: list
+      size: 471498


### PR DESCRIPTION
Many bricks have old stages from the brick-template.
